### PR TITLE
Remove libappindicator1 debian dependency for electron

### DIFF
--- a/electron/electron-builder.json
+++ b/electron/electron-builder.json
@@ -43,7 +43,6 @@
     "depends": [
       "gconf2",
       "gconf-service",
-      "libappindicator1",
       "libasound2",
       "libatk1.0-0",
       "libc6",


### PR DESCRIPTION
Change-type: patch