### PR TITLE
Set npm token in publish job so it can pull private modules if needed

### DIFF
--- a/npm/store.sh
+++ b/npm/store.sh
@@ -38,6 +38,9 @@ popd
 pushd $ARGV_DIRECTORY
 
 if egrep '(preversion|postversion|prepare|prepack|postpack|publish)' package.json; then
+  set +x
+  echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+  set -x
   npm install
 fi
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Giovanni Garufi <giovanni@balena.io>