### PR TITLE
Fix curl check to see if a repo is private for npm/store

### DIFF
--- a/npm/store.sh
+++ b/npm/store.sh
@@ -23,9 +23,9 @@ org=$(jq -r '.base_org' .git/.version)
 repo=$(jq -r '.base_repo' .git/.version)
 version=$(jq -r '.componentVersion' .git/.version)
 
-privateRepo=false
-if curl https://github.com/$org/$repo -I | grep -i 'status: 404'; then
-  privateRepo=true
+privateRepo=true
+if curl -s -o /dev/null -I -w "%{http_code}" https://github.com/$org/$repo -I | grep '200'; then
+  privateRepo=false
 fi
 
 popd


### PR DESCRIPTION
Also inverts the logic so that we default to considering the repo private and only set it to public when we can fetch its homepage on github

Change-type: patch
Signed-off-by: Giovanni Garufi <giovanni@balena.io>