### PR TITLE
Scan docker image with trivy

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -134,23 +134,27 @@ function build() {
   publish=$1; shift
   args=$1; shift
   secrets=$1; shift
+  sha_image=$(image_variant "${DOCKER_IMAGE}" "${sha}")
+  branch_image=$(image_variant "${DOCKER_IMAGE}" "build-${branch}")
+  master_image=$(image_variant "${DOCKER_IMAGE}" master)
+  latest_image=$(image_variant "${DOCKER_IMAGE}" latest)
 
   (
     cd "${path}"
 
     if [ "${publish}" != "false" ]; then
-      docker pull "$(image_variant "${DOCKER_IMAGE}" "${sha}")" || true
-      docker pull "$(image_variant "${DOCKER_IMAGE}" "build-${branch}")" || true
-      docker pull "$(image_variant "${DOCKER_IMAGE}" master)" || true
+      docker pull "${sha_image}" || true
+      docker pull "${branch_image}" || true
+      docker pull "${master_image}" || true
     fi
 
     # shellcheck disable=SC2086
     build_with_opts \
       "${DOCKERFILE}" \
       --progress=plain \
-      --cache-from "$(image_variant "${DOCKER_IMAGE}" "${sha}")" \
-      --cache-from "$(image_variant "${DOCKER_IMAGE}" "build-${branch}")" \
-      --cache-from "$(image_variant "${DOCKER_IMAGE}" master)" \
+      --cache-from "${sha_image}" \
+      --cache-from "${branch_image}" \
+      --cache-from "${master_image}" \
       ${args} \
       --build-arg RESINCI_REPO_COMMIT="${sha}" \
       --build-arg CI=true \
@@ -160,8 +164,11 @@ function build() {
       -t "${DOCKER_IMAGE}" \
       -f "${DOCKERFILE}" .
 
-    docker tag "$(image_variant "${DOCKER_IMAGE}")" "$(image_variant "${DOCKER_IMAGE}" latest)" || true
-    docker tag "$(image_variant "${DOCKER_IMAGE}" latest)" "$(image_variant "${DOCKER_IMAGE}" latest)"
+    docker tag $(image_variant ${DOCKER_IMAGE}) ${latest_image} || true
+
+    # Scan the image with trivy and output to stdout
+    trivy --no-progress --exit-code 0 --severity HIGH --ignore-unfixed ${latest_image}
+
     export_image "${DOCKER_IMAGE}" "${DOCKER_IMAGE_CACHE}"
   )
 }


### PR DESCRIPTION
When building a docker image, scan the image with [trivy](https://github.com/aquasecurity/trivy) just after tagging it. This is only for showing the output, build won't fail based on `trivy` results (yet).  An example of how this can look on a concourse build:
```
+ trivy --no-progress --exit-code 0 --severity HIGH --ignore-unfixed balenaci/vb-test:latest
2021-05-11T21:08:27.261Z	INFO	Need to update DB
2021-05-11T21:08:27.261Z	INFO	Downloading DB...
2021-05-11T21:08:29.760Z	INFO	Detecting Alpine vulnerabilities...
2021-05-11T21:08:29.761Z	INFO	Trivy skips scanning programming language libraries because no supported file was detected

balenaci/vb-test:latest (alpine 3.11.5)
=======================================
Total: 11 (HIGH: 11)

+--------------+------------------+----------+-------------------+---------------+---------------------------------------+
|   LIBRARY    | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                 TITLE                 |
+--------------+------------------+----------+-------------------+---------------+---------------------------------------+
| apk-tools    | CVE-2021-30139   | HIGH     | 2.10.4-r3         | 2.10.6-r0     | In Alpine Linux apk-tools             |
|              |                  |          |                   |               | before 2.12.5, the tarball            |
|              |                  |          |                   |               | parser allows a buffer...             |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-30139 |
+--------------+------------------+          +-------------------+---------------+---------------------------------------+
| busybox      | CVE-2021-28831   |          | 1.31.1-r9         | 1.31.1-r10    | busybox: invalid free or segmentation |
|              |                  |          |                   |               | fault via malformed gzip data         |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-28831 |
+--------------+------------------+          +-------------------+---------------+---------------------------------------+
| libcrypto1.1 | CVE-2020-1967    |          | 1.1.1d-r3         | 1.1.1g-r0     | openssl: Segmentation                 |
|              |                  |          |                   |               | fault in SSL_check_chain              |
|              |                  |          |                   |               | causes denial of service              |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-1967  |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2021-23840   |          |                   | 1.1.1j-r0     | openssl: integer                      |
|              |                  |          |                   |               | overflow in CipherUpdate              |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-23840 |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2021-3450    |          |                   | 1.1.1k-r0     | openssl: CA certificate check         |
|              |                  |          |                   |               | bypass with X509_V_FLAG_X509_STRICT   |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-3450  |
+--------------+------------------+          +-------------------+---------------+---------------------------------------+
| libgcc       | CVE-2019-15847   |          | 9.2.0-r4          | 9.3.0-r0      | gcc: POWER9 "DARN" RNG intrinsic      |
|              |                  |          |                   |               | produces repeated output              |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-15847 |
+--------------+------------------+          +-------------------+---------------+---------------------------------------+
| libssl1.1    | CVE-2020-1967    |          | 1.1.1d-r3         | 1.1.1g-r0     | openssl: Segmentation                 |
|              |                  |          |                   |               | fault in SSL_check_chain              |
|              |                  |          |                   |               | causes denial of service              |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-1967  |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2021-23840   |          |                   | 1.1.1j-r0     | openssl: integer                      |
|              |                  |          |                   |               | overflow in CipherUpdate              |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-23840 |
+              +------------------+          +                   +---------------+---------------------------------------+
|              | CVE-2021-3450    |          |                   | 1.1.1k-r0     | openssl: CA certificate check         |
|              |                  |          |                   |               | bypass with X509_V_FLAG_X509_STRICT   |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-3450  |
+--------------+------------------+          +-------------------+---------------+---------------------------------------+
| libstdc++    | CVE-2019-15847   |          | 9.2.0-r4          | 9.3.0-r0      | gcc: POWER9 "DARN" RNG intrinsic      |
|              |                  |          |                   |               | produces repeated output              |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-15847 |
+--------------+------------------+          +-------------------+---------------+---------------------------------------+
| ssl_client   | CVE-2021-28831   |          | 1.31.1-r9         | 1.31.1-r10    | busybox: invalid free or segmentation |
|              |                  |          |                   |               | fault via malformed gzip data         |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-28831 |
+--------------+------------------+----------+-------------------+---------------+---------------------------------------+

```

Change-type: minor
Signed-off-by: Stathis Moraitidis <stathis@balena.io>