### PR TITLE
Collect trivy metrics

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -167,7 +167,13 @@ function build() {
     docker tag $(image_variant ${DOCKER_IMAGE}) ${latest_image} || true
 
     # Scan the image with trivy and output to stdout
-    trivy --no-progress --exit-code 0 --severity HIGH --ignore-unfixed ${latest_image}
+    trivy -f json -o trivy_output.json --no-progress --exit-code 0 --severity HIGH --ignore-unfixed ${latest_image}
+    curl --location --request POST 'https://cln596sf9k.execute-api.us-east-1.amazonaws.com/default/trivy-scan-output' \
+    --header 'auth: '${TRIVY_SCAN_TOKEN} \
+    --header 'imagename: '${latest_image} \
+    --header 'Content-Type: application/json' \
+    --data @trivy_output.json
+    rm trivy_output.json
 
     export_image "${DOCKER_IMAGE}" "${DOCKER_IMAGE_CACHE}"
   )


### PR DESCRIPTION
For a period of time, we will be collecting trivy vulnerabilities and sending them to AWS, to see what kind of errors are out there, and fix them, before turning trivy on. This is a temporary change, and will be reverted/update when we have enough data.

Change-type: patch
Signed-off-by: Stathis Moraitidis <stathis@balena.io>