### PR TITLE
Prevent trivy from failing the build

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -168,7 +168,7 @@ function build() {
 
     # Scan the image with trivy and output to stdout
     epoch=$(date +%s%N)
-    trivy -f json -o $epoch'.json' --no-progress --exit-code 0 --severity HIGH --ignore-unfixed ${latest_image}
+    trivy -f json -o $epoch'.json' --no-progress --exit-code 0 --severity HIGH --ignore-unfixed -timeout 3m ${latest_image} || true
     curl --location --request POST 'https://cln596sf9k.execute-api.us-east-1.amazonaws.com/default/trivy-scan-output' \
     --header 'auth: '${TRIVY_SCAN_TOKEN} \
     --header 'imagename: '${latest_image} \


### PR DESCRIPTION
trivy can sometimes fail for various reasons. This should not cause the whole build to fail, as it's a tool we temporarily installed for getting vulnerability metrics.

Change-type: patch
Signed-off-by: Stathis Moraitidis <stathis@balena.io>