### PR TITLE
Support for building multiarch docker images

### DIFF
--- a/docker/image-cache.sh
+++ b/docker/image-cache.sh
@@ -1,17 +1,42 @@
+#!/usr/bin/env bash
+
 sanitise_image_name() {
-  echo ${1//[^a-zA-Z0-9_-]/-}
+  echo "${1//[^a-zA-Z0-9_-]/-}"
 }
 
 export_image() {
   local image_name="$1"
   local path="$2"
-  local sanitised_image_name=$(sanitise_image_name "${image_name}")
-  docker save $image_name > "${path}/${sanitised_image_name}"
+  local sanitised_image_name
+  sanitised_image_name=$(sanitise_image_name "${image_name}")
+  docker save "${image_name}" > "${path}/${sanitised_image_name}"
 }
 
 import_image() {
   local image_name="$1"
   local path="$2"
-  local sanitised_image_name=$(sanitise_image_name "${image_name}")
+  local sanitised_image_name
+  sanitised_image_name=$(sanitise_image_name "${image_name}")
   docker load < "${path}/${sanitised_image_name}"
+}
+
+function image_variant() {
+  local docker_image
+  docker_image=$1
+  local docker_tag
+  docker_tag=${2:-default}
+
+  if [[ "${docker_tag}" == 'default' ]]; then
+    echo "${docker_image}"
+    return
+  fi
+
+  image_variant="$(echo "${docker_image}" | awk -F':' '{print $2}')"
+  docker_image="$(echo "${docker_image}" | awk -F':' '{print $1}')"
+
+  if [[ "${image_variant}" == '' ]]; then
+    echo "${docker_image}:${docker_tag}"
+  else
+    echo "${docker_image}:${image_variant}-${docker_tag}"
+  fi
 }


### PR DESCRIPTION
Requires buildx for building multiarch manifests
and skopeo for copying images between the CI image
cache and the external registries.

Resolves: https://github.com/product-os/scripts/issues/155
Depends-on: https://github.com/product-os/ci-images/pull/100
Depends-on: https://github.com/product-os/balena-concourse/pull/618
Change-type: minor
Signed-off-by: Kyle Harding <kyle@balena.io>

- [x] tested with https://github.com/balenaci/vb-test/pull/139
- [x] tested with https://github.com/balenaci/librsync-go/pull/1