### PR TITLE
Increase trivy timeout

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -157,7 +157,7 @@ function build() {
       --exit-code 0 \
       --severity HIGH \
       --ignore-unfixed \
-      -timeout 1m \
+      --timeout 10m \
       "${latest_image}" || echo "Ignoring trivy call failure"
     curl --location --request POST 'https://cln596sf9k.execute-api.us-east-1.amazonaws.com/default/trivy-scan-output' \
       --header "auth: ${TRIVY_SCAN_TOKEN}" \


### PR DESCRIPTION
ci-pipeline raised issue:

```
2022-05-10T12:51:26.815Z	WARN	Increase --timeout value
2022-05-10T12:51:26.815Z	FATAL	scan error: image scan failed: failed analysis: analyze error: timeout: context deadline exceeded
```
Correct typo of trivy timeout argument (-- doubledash)


Change-type: patch