### PR TITLE
Split docker builds into single parallel context

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -176,37 +176,40 @@ function build() {
 }
 
 # Read the details of what we should build from .resinci.yml
-builds=$("${HERE}/../shared/resinci-read.sh" \
+read -ra builds "$("${HERE}/../shared/resinci-read.sh" \
   -b "$(pwd)" \
   -l docker \
-  -p builds | jq -c '.[]')
+  -p builds | jq -c 'group_by(.path)[]')"
 
 if [ -n "$builds" ]; then
-  build_pids=()
-  for build in ${builds}; do
-    echo "${build}"
-    repo=$(echo "${build}" | jq -r '.docker_repo')
-    dockerfile=$(echo "${build}" | jq -r '.dockerfile' || echo Dockerfile)
-    path=$(echo "${build}" | jq -r '.path' || echo .)
-    publish=$(echo "${build}" | jq -r '.publish' || echo true)
-    args=$(echo "${build}" | jq -r '.args // [] | map("--build-arg " + .) | join(" ")' || echo "")
-    secrets=$(echo "${build}" | jq -r '.secrets // [] | map("--secret id=" + .id + "," + "src=" + .src) | join(" ")' || echo "")
-    platforms="$(echo "${build}" | jq -r '.platforms // [] | join(",")' || echo "")"
+  for context in ${builds}; do
+    build_pids=()
+    read -ra build_context "$(echo "${context}" | jq -rc '.[]')"
+    for build in ${build_context}; do
+      echo "build: ${build}"
+      repo=$(echo "${build}" | jq -r '.docker_repo')
+      dockerfile=$(echo "${build}" | jq -r '.dockerfile' || echo Dockerfile)
+      build_path=$(echo "${build}" | jq -r '.path' || echo .)
+      publish=$(echo "${build}" | jq -r '.publish' || echo true)
+      args=$(echo "${build}" | jq -r '.args // [] | map("--build-arg " + .) | join(" ")' || echo "")
+      secrets=$(echo "${build}" | jq -r '.secrets // [] | map("--secret id=" + .id + "," + "src=" + .src) | join(" ")' || echo "")
+      platforms="$(echo "${build}" | jq -r '.platforms // [] | join(",")' || echo "")"
 
-    if [ "$repo" == "null" ]; then
-      echo "docker_repo must be set for every image. The value should be unique across the images in builds"
-      exit 1
-    fi
+      if [ -z "$repo" ]; then
+        echo "docker_repo must be set for every image. The value should be unique across the images in builds"
+        exit 1
+      fi
 
-    build "${path}" "${dockerfile}" "${repo}" "${publish}" "${args}" "${secrets}" "${platforms}" &
-    build_pids+=($!)
-  done
-  # Waiting on a specific PID makes the wait command return with the exit
-  # status of that process. Because of the 'set -e' setting, any exit status
-  # other than zero causes the current shell to terminate with that exit
-  # status as well.
-  for pid in "${build_pids[@]}"; do
-    wait "$pid"
+      build "${build_path}" "${dockerfile}" "${repo}" "${publish}" "${args}" "${secrets}" "${platforms}" &
+      build_pids+=($!)
+    done
+    # Waiting on a specific PID makes the wait command return with the exit
+    # status of that process. Because of the 'set -e' setting, any exit status
+    # other than zero causes the current shell to terminate with that exit
+    # status as well.
+    for pid in "${build_pids[@]}"; do
+      wait "$pid"
+    done
   done
 else
   if [ -f .resinci.yml ]; then

--- a/shared/resinci-read.sh
+++ b/shared/resinci-read.sh
@@ -60,7 +60,7 @@ if [ ! -f ${RESINCI_JSON} ]; then
   exit
 fi
 
-VALUE="$(yq e -j ${RESINCI_JSON} | jq -r ".[\"${ARGV_PIPELINE}\"].${ARGV_PROPERTY}")"
+VALUE="$(yq e -o=json ${RESINCI_JSON} | jq -r ".[\"${ARGV_PIPELINE}\"].${ARGV_PROPERTY}")"
 
 if [ "$VALUE" = "null" ]; then
   VALUE=""


### PR DESCRIPTION
Split parallel builts into context of single build paths.
Should be downwards compatible and should work with empty path key

Change-type: minor
Signed-off-by: fisehara <harald@balena.io>