### PR TITLE
Fix parallel build limiter

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -209,12 +209,14 @@ if [ -n "$builds" ]; then
     # status as well.
     # Limit maximum parallel builds to max_parallel_builds
     if [ "${#build_pids[@]}" -eq "${max_parallel_builds}" ]; then
-      echo "They are equal!"
       for pid in "${build_pids[@]}"; do
         wait "$pid"
       done
       build_pids=()
     fi
+  done
+  for pid in "${build_pids[@]}"; do
+    wait "$pid"
   done
 else
   if [ -f .resinci.yml ]; then


### PR DESCRIPTION
Wait for builds when they are pendning after starting

Change-type: patch
Signed-off-by: fisehara <harald@balena.io>